### PR TITLE
github-issue-6-week1-2-1-shadcn-flutter

### DIFF
--- a/lib/core/theme/app_theme.dart
+++ b/lib/core/theme/app_theme.dart
@@ -1,0 +1,16 @@
+import 'package:shadcn_flutter/shadcn_flutter.dart';
+import 'color_scheme.dart';
+import 'typography.dart';
+
+class AppTheme {
+  AppTheme._();
+
+  static ThemeData get light => _build(AppColorSchemes.light());
+  static ThemeData get dark => _build(AppColorSchemes.dark());
+
+  static ThemeData _build(ColorScheme colorScheme) => ThemeData(
+        colorScheme: colorScheme,
+        typography: AppTypography.geist,
+        radius: 0.5,
+      );
+}

--- a/lib/core/theme/color_scheme.dart
+++ b/lib/core/theme/color_scheme.dart
@@ -1,0 +1,9 @@
+import 'package:shadcn_flutter/shadcn_flutter.dart';
+
+class AppColorSchemes {
+  AppColorSchemes._();
+
+  static ColorScheme light() => ColorSchemes.lightZinc();
+
+  static ColorScheme dark() => ColorSchemes.darkZinc();
+}

--- a/lib/core/theme/typography.dart
+++ b/lib/core/theme/typography.dart
@@ -1,0 +1,7 @@
+import 'package:shadcn_flutter/shadcn_flutter.dart';
+
+class AppTypography {
+  AppTypography._();
+
+  static const Typography geist = Typography.geist();
+}

--- a/test/core/theme/app_theme_test.dart
+++ b/test/core/theme/app_theme_test.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart' show Brightness;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hobica/core/theme/app_theme.dart';
+
+void main() {
+  group('AppTheme', () {
+    group('light', () {
+      test('ライトモード用 ThemeData を返す', () {
+        final theme = AppTheme.light;
+        expect(theme, isNotNull);
+        expect(theme.colorScheme.brightness, Brightness.light);
+      });
+
+      test('radius が設定されている', () {
+        final theme = AppTheme.light;
+        expect(theme.radius, 0.5);
+      });
+
+      test('typography が設定されている', () {
+        final theme = AppTheme.light;
+        expect(theme.typography, isNotNull);
+      });
+    });
+
+    group('dark', () {
+      test('ダークモード用 ThemeData を返す', () {
+        final theme = AppTheme.dark;
+        expect(theme, isNotNull);
+        expect(theme.colorScheme.brightness, Brightness.dark);
+      });
+
+      test('radius が設定されている', () {
+        final theme = AppTheme.dark;
+        expect(theme.radius, 0.5);
+      });
+
+      test('typography が設定されている', () {
+        final theme = AppTheme.dark;
+        expect(theme.typography, isNotNull);
+      });
+    });
+
+    test('light と dark は異なるカラースキームを持つ', () {
+      final light = AppTheme.light;
+      final dark = AppTheme.dark;
+      expect(
+        light.colorScheme.background,
+        isNot(equals(dark.colorScheme.background)),
+      );
+    });
+
+    test('light と dark は同じ radius を持つ', () {
+      expect(AppTheme.light.radius, AppTheme.dark.radius);
+    });
+  });
+}

--- a/test/core/theme/color_scheme_test.dart
+++ b/test/core/theme/color_scheme_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart' show Brightness;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hobica/core/theme/color_scheme.dart';
+
+void main() {
+  group('AppColorSchemes', () {
+    test('light() は Brightness.light のカラースキームを返す', () {
+      final scheme = AppColorSchemes.light();
+      expect(scheme.brightness, Brightness.light);
+    });
+
+    test('dark() は Brightness.dark のカラースキームを返す', () {
+      final scheme = AppColorSchemes.dark();
+      expect(scheme.brightness, Brightness.dark);
+    });
+
+    test('light() と dark() は異なるカラースキームを返す', () {
+      final light = AppColorSchemes.light();
+      final dark = AppColorSchemes.dark();
+      expect(light.background, isNot(equals(dark.background)));
+    });
+
+    test('light() は必須カラーを全て持つ', () {
+      final scheme = AppColorSchemes.light();
+      expect(scheme.background, isNotNull);
+      expect(scheme.foreground, isNotNull);
+      expect(scheme.primary, isNotNull);
+      expect(scheme.primaryForeground, isNotNull);
+      expect(scheme.secondary, isNotNull);
+      expect(scheme.destructive, isNotNull);
+    });
+
+    test('dark() は必須カラーを全て持つ', () {
+      final scheme = AppColorSchemes.dark();
+      expect(scheme.background, isNotNull);
+      expect(scheme.foreground, isNotNull);
+      expect(scheme.primary, isNotNull);
+      expect(scheme.primaryForeground, isNotNull);
+      expect(scheme.secondary, isNotNull);
+      expect(scheme.destructive, isNotNull);
+    });
+  });
+}

--- a/test/core/theme/typography_test.dart
+++ b/test/core/theme/typography_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hobica/core/theme/typography.dart';
+
+void main() {
+  group('AppTypography', () {
+    test('geist は Typography インスタンスを返す', () {
+      final typography = AppTypography.geist;
+      expect(typography, isNotNull);
+    });
+
+    test('geist はセマンティックスタイルを持つ', () {
+      final typography = AppTypography.geist;
+      expect(typography.h1, isNotNull);
+      expect(typography.h2, isNotNull);
+      expect(typography.h3, isNotNull);
+      expect(typography.p, isNotNull);
+    });
+
+    test('geist はサイズスタイルを持つ', () {
+      final typography = AppTypography.geist;
+      expect(typography.small, isNotNull);
+      expect(typography.base, isNotNull);
+      expect(typography.large, isNotNull);
+      expect(typography.x2Large, isNotNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

ライト/ダークモード対応のテーマシステム実装（app_theme.dart, color_scheme.dart, typography.dart）

## Execution Report

Piece `frontend` completed successfully.

Closes #6